### PR TITLE
Remove lodash from manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
         "@babel/preset-react": "^7.0.0",
         "cross-env": "^5.2.0",
         "laravel-mix": "^4.1.2",
-        "lodash": "^4.17.15",
         "sass": "^1.22.10",
         "sass-loader": "^7.3.1"
     },


### PR DESCRIPTION
I don't think this is used :) If I'm missing something, we should probably consider taking it out of `devDependencies`.