### PR TITLE
add labels for times on meeting detail page when there are two

### DIFF
--- a/src/components/Meeting.tsx
+++ b/src/components/Meeting.tsx
@@ -296,17 +296,22 @@ export default function Meeting() {
           <div>
             <div>
               <h2>{strings.meeting_information}</h2>
-              <p>{formatTime(meeting.start, meeting.end)}</p>
-              {meeting.start && meeting.start.zoneName !== meeting.timezone && (
-                <p>
-                  (
-                  {formatTime(
-                    meeting.start.setZone(meeting.timezone),
-                    meeting.end?.setZone(meeting.timezone)
-                  )}
-                  )
-                </p>
-              )}
+              {meeting.start &&
+                (meeting.start.zoneName === meeting.timezone ? (
+                  <p>{formatTime(meeting.start, meeting.end)}</p>
+                ) : (
+                  <dl>
+                    <dt>{strings.your_time}</dt>
+                    <dd>{formatTime(meeting.start, meeting.end)}</dd>
+                    <dt>{strings.local_time}</dt>
+                    <dd>
+                      {formatTime(
+                        meeting.start.setZone(meeting.timezone),
+                        meeting.end?.setZone(meeting.timezone)
+                      )}
+                    </dd>
+                  </dl>
+                ))}
               {capabilities.type && meeting.types && (
                 <ul>
                   {meeting.types

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -42,6 +42,7 @@ export const en: Translation = {
   in_progress_single: '1 meeting in progress',
   in_progress_multiple: '%count% meetings in progress',
   km: 'km',
+  local_time: 'Local Time',
   location: 'Location',
   location_group: 'Location / Group',
   match_single: '1 result',
@@ -99,4 +100,5 @@ export const en: Translation = {
     map: 'Map',
   },
   weekday_any: 'Any Day',
+  your_time: 'Your Time',
 };

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -42,6 +42,7 @@ export const es: Translation = {
   in_progress_single: '1 reunión en curso',
   in_progress_multiple: '%count% reuniones en curso',
   km: 'km',
+  local_time: 'Hora local',
   location: 'Ubicación',
   location_group: 'Ubicación / Grupo',
   match_single: '1 resultado',
@@ -99,4 +100,5 @@ export const es: Translation = {
     map: 'Mapa',
   },
   weekday_any: 'Cualquier día',
+  your_time: 'Su hora',
 };

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -42,6 +42,7 @@ export const fr: Translation = {
   in_progress_single: '1 réunion en cours',
   in_progress_multiple: '%count% rendez-vous en cours',
   km: 'km',
+  local_time: 'Heure locale',
   location: 'Emplacement',
   location_group: 'Emplacement / Groupe',
   match_single: '1 résultat',
@@ -99,4 +100,5 @@ export const fr: Translation = {
     map: 'Carte',
   },
   weekday_any: 'Tous les jours',
+  your_time: 'Votre heure',
 };

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -42,6 +42,7 @@ export const ja: Translation = {
   in_progress_single: '1件のミーティングが進行中です',
   in_progress_multiple: '%count% ミーティングが進行中です',
   km: 'キロ',
+  local_time: '現地時間',
   location: '位置',
   location_group: '場所・グループ',
   match_single: '1件の結果',
@@ -99,4 +100,5 @@ export const ja: Translation = {
     map: '地図',
   },
   weekday_any: '曜日指定無し',
+  your_time: 'あなたの時間',
 };

--- a/src/i18n/nl.ts
+++ b/src/i18n/nl.ts
@@ -42,6 +42,7 @@ export const nl: Translation = {
   in_progress_single: '1 meeting bezig',
   in_progress_multiple: '%count% meetings bezig',
   km: 'km',
+  local_time: 'Lokale Tijd',
   location: 'Locatie',
   location_group: 'Locatie / Groep',
   match_single: '1 resultaat',
@@ -50,7 +51,7 @@ export const nl: Translation = {
   meetings: 'Meetings',
   mi: 'mi',
   midday: 'Middag',
-  'modes': {
+  modes: {
     location: 'Vlakbij Locatie',
     me: 'Vlakbij Me',
     search: 'Zoeken',
@@ -100,4 +101,5 @@ export const nl: Translation = {
     map: 'Kaart',
   },
   weekday_any: 'Elke Dag',
+  your_time: 'Uw Tijd',
 };

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -42,6 +42,7 @@ export const pt: Translation = {
   in_progress_single: '1 reunião em progresso',
   in_progress_multiple: '%count% reuniões em progresso',
   km: 'km',
+  local_time: 'Hora Local',
   location: 'Localização',
   location_group: 'Local / Grupo',
   match_single: '1 resultado',
@@ -100,4 +101,5 @@ export const pt: Translation = {
     map: 'Mapa',
   },
   weekday_any: 'Qualquer Dia',
+  your_time: 'Sua Hora',
 };

--- a/src/i18n/sk.ts
+++ b/src/i18n/sk.ts
@@ -42,6 +42,7 @@ export const sk: Translation = {
   in_progress_single: '1 stretnutie práve prebieha',
   in_progress_multiple: '%count% práve prebiehajúce stretnutia',
   km: 'km',
+  local_time: 'Miesta Čas',
   location: 'Poloha',
   location_group: 'Poloha / Skupina',
   match_single: '1 výsledok',
@@ -100,4 +101,5 @@ export const sk: Translation = {
     map: 'Mapa',
   },
   weekday_any: 'Ktorýkoľvek deň',
+  your_time: 'Váš čas',
 };

--- a/src/i18n/sv.ts
+++ b/src/i18n/sv.ts
@@ -42,6 +42,7 @@ export const sv: Translation = {
   in_progress_single: '1 möte pågår',
   in_progress_multiple: '%count% möten pågår',
   km: 'km',
+  local_time: 'Lokal Tid',
   location: 'Plats',
   location_group: 'Plats / Grupp',
   match_single: '1 resultat',
@@ -99,4 +100,5 @@ export const sv: Translation = {
     map: 'Karta',
   },
   weekday_any: 'Alla Dagar',
+  your_time: 'Din Tid',
 };

--- a/src/i18n/th.ts
+++ b/src/i18n/th.ts
@@ -45,6 +45,7 @@ export const th: Translation = {
   in_progress_single: 'กำลังประชุมอยู่ 1 รายการ',
   in_progress_multiple: 'กำลังประชุมอยู่ %count% รายการ',
   km: 'กม.',
+  local_time: 'เวลาท้องถิ่น',
   location: 'สถานที่',
   location_group: 'สถานที่ / กลุ่ม',
   match_single: 'พบ 1 รายการ',
@@ -102,4 +103,5 @@ export const th: Translation = {
     map: 'แผนที่',
   },
   weekday_any: 'ทุกวัน',
+  your_time: 'เวลาของคุณ',
 };

--- a/src/styles/meeting.ts
+++ b/src/styles/meeting.ts
@@ -22,6 +22,12 @@ export const meetingColumnsCss = css`
     margin: 0;
   }
 
+  dl {
+    display: grid;
+    gap: ${size.gutter / 2}px;
+    grid-template-columns: 1fr 1fr;
+  }
+
   ul {
     padding: 0 0 0 ${size.gutter * 1.5}px;
     button {

--- a/src/types/Translation.ts
+++ b/src/types/Translation.ts
@@ -40,6 +40,7 @@ export interface Translation {
   in_progress_single: string;
   in_progress_multiple: string;
   km: string;
+  local_time: string;
   location: string;
   location_group: string;
   match_single: string;
@@ -87,4 +88,5 @@ export interface Translation {
     map: string;
   };
   weekday_any: string;
+  your_time: string;
 }


### PR DESCRIPTION
fix #531 

usually TSML UI displays a single time for a meeting, like this: 

<img width="1062" height="534" alt="default" src="https://github.com/user-attachments/assets/75748878-b017-4a59-af07-de57ef894d51" />

that's not changing. 

sometimes, however, if the meeting time is being converted into a user's local time (such as for sites that list meetings in various timezones) then we show two times on the meeting detail page, like this:

<img width="1182" height="522" alt="before" src="https://github.com/user-attachments/assets/2d23fecc-1a86-4832-a623-8a4e383379d4" />

this PR adds labels to clarify what you're seeing:

<img width="1166" height="528" alt="after" src="https://github.com/user-attachments/assets/1b7d75d6-ae12-4373-998c-7e803c5e0aee" />
